### PR TITLE
Expose task description in Chores4Kids tasks sensor attributes

### DIFF
--- a/custom_components/chores4kids/sensor.py
+++ b/custom_components/chores4kids/sensor.py
@@ -215,6 +215,7 @@ class Chores4KidsAllTasksSensor(SensorEntity):
             "title": t.title,
             "points": t.points,
             "status": t.status,
+            "description": getattr(t, "description", "") or "",
             "due": t.due,
             "repeat_template_id": getattr(t, "repeat_template_id", None),
             "early_bonus_enabled": getattr(t, "early_bonus_enabled", False),


### PR DESCRIPTION
This fixes an issue where task descriptions were lost when editing tasks in the frontend because the backend sensor `sensor.chores4kids_tasks` did not include the `description` field in its attributes.

Added `description` to the dictionary comprehension in `Chores4KidsAllTasksSensor.extra_state_attributes` in `custom_components/chores4kids/sensor.py`.

_Note: This was generated by gemini 3. I tested it manually and it works._