### PR TITLE
feat: Add mark_overdue option to tasks

### DIFF
--- a/custom_components/chores4kids/__init__.py
+++ b/custom_components/chores4kids/__init__.py
@@ -66,6 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             categories=call.data.get("categories"),
             fastest_wins=call.data.get("fastest_wins"),
             schedule_mode=call.data.get("schedule_mode"),
+            mark_overdue=call.data.get("mark_overdue"),
         )
         async_dispatcher_send(hass, SIGNAL_DATA_UPDATED)
 
@@ -105,6 +106,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             skip_approval=call.data.get("skip_approval"),
             categories=call.data.get("categories"),
             fastest_wins=call.data.get("fastest_wins"),
+            mark_overdue=call.data.get("mark_overdue"),
         )
         async_dispatcher_send(hass, SIGNAL_DATA_UPDATED)
 

--- a/custom_components/chores4kids/sensor.py
+++ b/custom_components/chores4kids/sensor.py
@@ -172,6 +172,7 @@ class KidsChoresPointsSensor(SensorEntity):
             "fastest_wins_claimed_by_child_id": getattr(t, "fastest_wins_claimed_by_child_id", None),
             "fastest_wins_claimed_by_child_name": getattr(t, "fastest_wins_claimed_by_child_name", None),
             "fastest_wins_claimed_ts": getattr(t, "fastest_wins_claimed_ts", None),
+            "mark_overdue": getattr(t, "mark_overdue", True),
         } for t in tasks]
         return {
             "child_id": ch.id,
@@ -239,6 +240,7 @@ class Chores4KidsAllTasksSensor(SensorEntity):
             "fastest_wins_claimed_by_child_id": getattr(t, "fastest_wins_claimed_by_child_id", None),
             "fastest_wins_claimed_by_child_name": getattr(t, "fastest_wins_claimed_by_child_name", None),
             "fastest_wins_claimed_ts": getattr(t, "fastest_wins_claimed_ts", None),
+            "mark_overdue": getattr(t, "mark_overdue", True),
         } for t in self._store.tasks]
         categories = [
             {

--- a/custom_components/chores4kids/services.yaml
+++ b/custom_components/chores4kids/services.yaml
@@ -63,6 +63,11 @@ add_task:
       description: "Scheduling mode for templates: repeat (use repeat_days), weekly (every Monday), monthly (1st of month)"
       example: "weekly"
 
+    mark_overdue:
+      required: false
+      description: "If true, unfinished task carried to next day is marked as overdue (red). Default true."
+      example: true
+
     fastest_wins:
       required: false
       description: "If true, and the task template is assigned to multiple children, the first child to start/complete it will claim it; other children's copies will show who claimed it and cannot be started"
@@ -134,6 +139,11 @@ update_task:
     categories:
       required: false
       description: "List of category ids to set on the task"
+
+    mark_overdue:
+      required: false
+      description: "If true, unfinished task carried to next day is marked as overdue (red)."
+      example: true
 
     fastest_wins:
       required: false


### PR DESCRIPTION
This adds backend support for the `mark_overdue` field on tasks, which controls whether unfinished tasks carried over to the next day are visually marked as overdue.

Changes:
- Added `mark_overdue` boolean field to `Task` dataclass (default: True).
- Updated `add_task` and `update_task` services to accept `mark_overdue`.
- Updated `storage.py` to persist `mark_overdue` and propagate it when spawning repeat instances or rolling over tasks.
- Exposed `mark_overdue` in sensor attributes for frontend consumption.

Works with https://github.com/qlerup/lovelace-chores4kids-card/pull/24